### PR TITLE
Refactor/use anyhow errors in core-dockpack

### DIFF
--- a/core-dockpack/Cargo.toml
+++ b/core-dockpack/Cargo.toml
@@ -16,3 +16,4 @@ futures-util = "0.3.31"
 tokio-util = { version = "0.7.14", features = ["io"] }
 tokio-tar = "0.3.1"
 futures-core = "0.3.31"
+anyhow = "1.0.98"

--- a/core-dockpack/src/cmd_processes/build/build_dockerfile.rs
+++ b/core-dockpack/src/cmd_processes/build/build_dockerfile.rs
@@ -1,20 +1,27 @@
 //! Builds a Dockerfile from a directory
 
+use anyhow::{Context, Result};
 use std::fs::File;
 use std::io::Write;
 
 // directory is the build context
 
-pub fn create_dockerfile(directory: &str) -> Result<(), String> {
+pub fn create_dockerfile(directory: &str) -> Result<()> {
     let docker_file_content = "FROM scratch\nCOPY . .\n".to_string();
 
     let dockerfile_path = format!("{}/Dockerfile", directory);
 
-    let mut dockerfile = File::create(&dockerfile_path).map_err(|e| e.to_string())?;
+    let mut dockerfile = File::create(&dockerfile_path)
+        .with_context(|| format!("Error creatining file at path {}", dockerfile_path))?;
 
     dockerfile
         .write_all(docker_file_content.as_bytes())
-        .map_err(|e| e.to_string())?;
+        .with_context(|| {
+            format!(
+                "Could not write all from scratch content to dockerfile at path {}",
+                dockerfile_path,
+            )
+        })?;
 
     Ok(())
 }

--- a/core-dockpack/src/cmd_processes/pull/unpack_files.rs
+++ b/core-dockpack/src/cmd_processes/pull/unpack_files.rs
@@ -46,6 +46,6 @@ mod tests {
         assert!(result.is_ok());
         let path = result.unwrap();
         assert!(Path::new(&path).exists());
-        // fs::remove_dir_all(directory).unwrap();
+        fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/core-dockpack/src/cmd_processes/pull/unpack_files.rs
+++ b/core-dockpack/src/cmd_processes/pull/unpack_files.rs
@@ -1,5 +1,6 @@
 //! The API for unpacking Docker images into a directory.
 use crate::utils::{cache, docker_commands, unpacking};
+use anyhow::Result;
 use std::path::PathBuf;
 
 /// Unpacks the files from a Docker image into a directory.
@@ -10,7 +11,7 @@ use std::path::PathBuf;
 ///
 /// # Returns
 /// The path to the directory where the Docker image files are stored.
-pub async fn unpack_files_from_image(image: &str, directory: &str) -> Result<String, String> {
+pub async fn unpack_files_from_image(image: &str, directory: &str) -> Result<String> {
     let main_path = PathBuf::from(directory);
     cache::wipe_and_create_cache(&main_path);
 

--- a/core-dockpack/src/cmd_processes/push/execute_push.rs
+++ b/core-dockpack/src/cmd_processes/push/execute_push.rs
@@ -37,7 +37,6 @@ pub async fn execute_docker_build(directory: &str, image: &str) -> Result<()> {
     let options = CreateImageOptionsBuilder::default()
         .from_src("-") // from_src must be "-" when sending the archive in the request body
         .repo(image) // The name of the image in the docker daemon.
-        .tag("1.0.0") // The tag of this particular image.
         .build();
     let _: Vec<CreateImageInfo> = docker
         .create_image(Some(options), Some(bollard::body_try_stream(stream)), None)
@@ -47,7 +46,7 @@ pub async fn execute_docker_build(directory: &str, image: &str) -> Result<()> {
 
     let options = PushImageOptionsBuilder::new().tag("latest").build();
     let _: Vec<PushImageInfo> = docker
-        .push_image(&cache::process_image_name(image), Some(options), None)
+        .push_image(image, Some(options), None)
         .try_collect()
         .await
         .with_context(|| "Could not push image")?;

--- a/core-dockpack/src/cmd_processes/push/execute_push.rs
+++ b/core-dockpack/src/cmd_processes/push/execute_push.rs
@@ -66,7 +66,7 @@ mod tests {
 
         assert!(result.is_ok());
 
-        // fs::remove_dir_all(directory).expect("Failed to remove test directory");
+        fs::remove_dir_all(directory).expect("Failed to remove test directory");
     }
 
     #[tokio::test]
@@ -82,6 +82,6 @@ mod tests {
         let result = execute_docker_build(directory, image_name).await;
         assert!(result.is_ok());
 
-        // fs::remove_dir_all(directory).expect("Failed to remove test directory");
+        fs::remove_dir_all(directory).expect("Failed to remove test directory");
     }
 }

--- a/core-dockpack/src/cmd_processes/push/execute_push.rs
+++ b/core-dockpack/src/cmd_processes/push/execute_push.rs
@@ -25,12 +25,9 @@ pub async fn execute_docker_build(directory: &str, image: &str) -> Result<()> {
     // Convert directory to a tar file
     let tar_path = dir_to_tar(directory, image).await?;
 
-    let file = File::open(tar_path).await.with_context(|| {
-        format!(
-            "Could not find archive at path {}.",
-            format!("{}.tar", image)
-        )
-    })?;
+    let file = File::open(tar_path)
+        .await
+        .with_context(|| format!("Could not find archive at path {}.tar", image))?;
     let stream = ReaderStream::new(file);
 
     let docker = Docker::connect_with_socket_defaults()

--- a/core-dockpack/src/cmd_processes/push/execute_push.rs
+++ b/core-dockpack/src/cmd_processes/push/execute_push.rs
@@ -31,7 +31,7 @@ pub async fn execute_docker_build(directory: &str, image: &str) -> Result<()> {
     let stream = ReaderStream::new(file);
 
     let docker = Docker::connect_with_socket_defaults()
-        .with_context(|| "Could no connect to docker socket. Is docker running?")?;
+        .with_context(|| "Could not connect to docker socket. Is docker running?")?;
 
     let options = bollard::query_parameters::CreateImageOptionsBuilder::default()
         .from_src("-") // from_src must be "-" when sending the archive in the request body

--- a/core-dockpack/src/utils/docker_commands.rs
+++ b/core-dockpack/src/utils/docker_commands.rs
@@ -1,21 +1,21 @@
 //! Defines the actions around downloading and unpacking docker images to access the files.
 use super::cache::process_image_name;
 use anyhow::{anyhow, Context, Result};
-use bollard::image::CreateImageOptions;
+use bollard::query_parameters::CreateImageOptionsBuilder;
 use bollard::Docker;
 use futures_util::stream::TryStreamExt;
 use futures_util::StreamExt;
-use std::default::Default;
 use std::process::Command;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 use tokio_tar::Archive;
 
 async fn pull_image(image_name: &str, docker: &Docker) -> Result<()> {
-    let options = Some(CreateImageOptions {
-        from_image: image_name,
-        ..Default::default()
-    });
+    let options = Some(
+        CreateImageOptionsBuilder::new()
+            .from_image(image_name)
+            .build(),
+    );
     println!("image_name: {}", image_name);
     // confirmed: this works
     docker

--- a/core-dockpack/src/utils/unpacking.rs
+++ b/core-dockpack/src/utils/unpacking.rs
@@ -58,8 +58,8 @@ pub fn extract_layers(main_path: &str, unpack_path: &str) -> Result<String> {
         std::fs::create_dir_all(unpack_path).with_context(|| "Error creating directory")?;
     }
 
-    let manifest = read_json_file(&manifest_path)
-        .with_context(|| format!("Error reading json manifest file"))?;
+    let manifest =
+        read_json_file(&manifest_path).with_context(|| "Error reading json manifest file")?;
 
     if let Some(layers) = manifest[0]["Layers"].as_array() {
         println!("Found {} layers in manifest", layers.len());
@@ -78,10 +78,9 @@ pub fn extract_layers(main_path: &str, unpack_path: &str) -> Result<String> {
             });
 
             // Extract the layer's tarball to a directory
-            let mut tar_file =
-                File::open(&layer_path).with_context(|| format!("Error reading tar file"))?;
+            let mut tar_file = File::open(&layer_path).with_context(|| "Error reading tar file")?;
             let if_gzipped = check_if_gzipped(&mut tar_file)
-                .with_context(|| format!("Erorr checcking if tar fle is gzipped"))?;
+                .with_context(|| "Error checking if tar fle is gzipped")?;
             match if_gzipped {
                 true => {
                     println!("Layer is gzipped");

--- a/coredockpack/Cargo.toml
+++ b/coredockpack/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 core-dockpack = { path = "../core-dockpack" }
+tokio = "1.45.1"
 
 
 [lib]

--- a/coredockpack/src/lib.rs
+++ b/coredockpack/src/lib.rs
@@ -12,6 +12,7 @@ use std::os::raw::c_char;
 /// A C string with the path to the directory where the Docker image files are stored.
 /// On error, returns a null pointer.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[allow(improper_ctypes_definitions)]
 #[no_mangle]
 pub async extern "C" fn unpack_files_from_image_c(
     image: *const c_char,

--- a/coredockpack/src/lib.rs
+++ b/coredockpack/src/lib.rs
@@ -1,6 +1,7 @@
 use core_dockpack::cmd_processes::pull::unpack_files::unpack_files_from_image;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
+use tokio::runtime::Runtime;
 
 /// Unpacks the files from a Docker image into a directory.
 ///
@@ -12,9 +13,8 @@ use std::os::raw::c_char;
 /// A C string with the path to the directory where the Docker image files are stored.
 /// On error, returns a null pointer.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[allow(improper_ctypes_definitions)]
 #[no_mangle]
-pub async extern "C" fn unpack_files_from_image_c(
+pub extern "C" fn unpack_files_from_image_c(
     image: *const c_char,
     directory: *const c_char,
 ) -> *const c_char {
@@ -22,7 +22,9 @@ pub async extern "C" fn unpack_files_from_image_c(
     let image = unsafe { CStr::from_ptr(image).to_string_lossy().into_owned() };
     let directory = unsafe { CStr::from_ptr(directory).to_string_lossy().into_owned() };
 
-    match unpack_files_from_image(&image, &directory).await {
+    let rt = Runtime::new().unwrap();
+    let result = rt.block_on(unpack_files_from_image(&image, &directory));
+    match result {
         Ok(path) => {
             let c_string = CString::new(path).unwrap();
             c_string.into_raw() // Return the C string


### PR DESCRIPTION
# Changes
* Add anyhow crate to `core-dockpack`. Error types are then box dyn error via anyhow rather than Strings.
* Remove all instances of `expect` that could cause panicks for regular errors in `dockpack_push`.
* Fix on `execute_docker_build` so that `test_execute_push` does not fail.
* Remove use of deprecated struct `CreateImageOptions` in favour of `CreateImageOptionsBuilder`.
* Add allow C for clippy lint.

# Reason for Change
* It was becoming a bit difficult to track the errors when developing, with plain `errors -> string`. Since I want to add some features, now seemed like the right time to refactor.
* I accidentally introduced a regression in the dockpack push command, by not reading the right image tar in `execute_docker_build`.
* Changes to comply with clippy (all pre-commit hooks now pass).