### PR TITLE
feat: push built image to remote

### DIFF
--- a/core-dockpack/src/cmd_processes/push/execute_push.rs
+++ b/core-dockpack/src/cmd_processes/push/execute_push.rs
@@ -1,5 +1,6 @@
 use crate::utils::cache;
-use bollard::models::CreateImageInfo;
+use bollard::models::{CreateImageInfo, PushImageInfo};
+use bollard::query_parameters::{CreateImageOptionsBuilder, PushImageOptionsBuilder};
 use bollard::Docker;
 use futures_util::stream::TryStreamExt;
 use tokio::fs::File;
@@ -32,17 +33,23 @@ pub async fn execute_docker_build(directory: &str, image: &str) -> Result<(), St
     let docker = Docker::connect_with_socket_defaults()
         .expect("Could no connect to docker socket. Is docker running?");
 
-    let options = bollard::query_parameters::CreateImageOptionsBuilder::default()
+    let options = CreateImageOptionsBuilder::default()
         .from_src("-") // from_src must be "-" when sending the archive in the request body
         .repo(image) // The name of the image in the docker daemon.
         .tag("1.0.0") // The tag of this particular image.
         .build();
-
     let _: Vec<CreateImageInfo> = docker
         .create_image(Some(options), Some(bollard::body_try_stream(stream)), None)
         .try_collect()
         .await
         .expect("Could not create image");
+
+    let options = PushImageOptionsBuilder::new().tag("latest").build();
+    let _: Vec<PushImageInfo> = docker
+        .push_image(&cache::process_image_name(image), Some(options), None)
+        .try_collect()
+        .await
+        .expect("Could not push image");
 
     Ok(())
 }


### PR DESCRIPTION
# Change
* Pushes the built docker image to a remote repo. (just like docker push
* Tests will not yet pass - needs to be able to auth to the remote image in the push test. We will need a strategy to formulate this in the test - I will give it some thought but would love some input. Might see if I can pinch anything from the `bollard` tests.
# Reason for Change
* `docker push` pushes to remote repo. I suppose `docpack push` should too.
# PR status/Future improvement
* I'm going to wait until the [refactoring PR](https://github.com/maxwellflitton/dockpack/pull/12) is merged until finishing this off. Then, it will be straightforward to merge in its changes and remove the new `.expect` here.
* Might want to add a feature flag for push/not push to remote, if someone wants to build the image locally and not push (e.g. to serve/test the image locally). However, we wouldn't need that flag if we made `dockpack build` do what I expect; build the image (like `dockpack push` does now). Right now, `dockpack build` only "builds" the docker file itself.
